### PR TITLE
Update Command.php

### DIFF
--- a/src/PhpOrient/Protocols/Binary/Operations/Command.php
+++ b/src/PhpOrient/Protocols/Binary/Operations/Command.php
@@ -190,7 +190,7 @@ class Command extends Operation {
         } else {
             $res = $this->_read_sync();
             if( $this->command == Constants::QUERY_CMD ){
-                return $res[0];
+                if (isset($res[0])) return $res[0];
             }
             return $res;
         }


### PR DESCRIPTION
Some commands return a null response from OrientDB which produces an offset error like this:

	ERROR: exception 'ErrorException' with message 'Undefined offset: 0' in C:\git\backend\vendor\ostico\phporient\src\PhpOrient\Protocols\Binary\Operations\Command.php:193

Error is caused by returning $res[0] when $res[0] does not exist. For example, running this OrientDB command:

	orientdb {db=z}>  create edge rProductChannelProduct from #19:11258 to (select from tPr where Br = 'YL5' and SU = '330902' and first(out_rPro.in) = #18:6)
	Created edge '[]' in 0.002000 sec(s).
	orientdb {db=z}>

Fix: test for $res[0] before returning it.