### PR TITLE
Allow the results of basic queries to be fetched in child classes of Record

### DIFF
--- a/src/PhpOrient/PhpOrient.php
+++ b/src/PhpOrient/PhpOrient.php
@@ -74,6 +74,11 @@ class PhpOrient implements ConfigurableInterface {
     protected $_transport;
 
     /**
+     * @var bool
+     */
+    protected static $fetchClass = false;
+
+    /**
      * Class Constructor
      *
      * @param string $hostname The server host.
@@ -205,7 +210,9 @@ class PhpOrient implements ConfigurableInterface {
      * @return mixed The result of the operation.
      */
     public function execute( $operation, Array $params = array() ) {
-        return $this->getTransport()->execute( $operation, $params );
+        $result = $this->getTransport()->execute( $operation, $params );
+        $this->setFetchClass(false);
+        return $result;
     }
 
     /**
@@ -263,7 +270,9 @@ class PhpOrient implements ConfigurableInterface {
         $params[ 'command' ] = Constants::QUERY_CMD;
         $params[ 'query' ]   = $query;
 
-        return $this->getTransport()->execute( 'command', $params );
+        $result = $this->getTransport()->execute( 'command', $params );
+        $this->setFetchClass(false);
+        return $result;
     }
 
     /**
@@ -284,7 +293,9 @@ class PhpOrient implements ConfigurableInterface {
         $params[ 'limit' ]      = ( !stripos( $query, ' limit ' ) ? $limit : -1 );
         $params[ 'fetch_plan' ] = $fetchPlan;
 
-        return $this->getTransport()->execute( 'command', $params );
+        $result = $this->getTransport()->execute( 'command', $params );
+        $this->setFetchClass(false);
+        return $result;
     }
 
     /**
@@ -302,7 +313,9 @@ class PhpOrient implements ConfigurableInterface {
         $params[ 'command' ]    = Constants::QUERY_ASYNC;
         $params[ 'query' ]      = $query;
 
-        return $this->getTransport()->execute( 'command', $params );
+        $result = $this->getTransport()->execute( 'command', $params );
+        $this->setFetchClass(false);
+        return $result;
     }
 
     /**
@@ -319,7 +332,9 @@ class PhpOrient implements ConfigurableInterface {
         $params[ 'command' ] = Constants::QUERY_SCRIPT;
         $params[ 'query' ]   = $param;
 
-        return $this->getTransport()->execute( 'command', $params );
+        $result = $this->getTransport()->execute( 'command', $params );
+        $this->setFetchClass(false);
+        return $result;
     }
 
     /**
@@ -330,13 +345,15 @@ class PhpOrient implements ConfigurableInterface {
      * @return RecordUpdate|Record
      */
     public function recordUpdate( Record $record ) {
-        return $this->getTransport()->execute( 'recordUpdate',
+        $result = $this->getTransport()->execute( 'recordUpdate',
             [
                 'rid'              => $record->getRid(),
                 'record'           => $record,
                 'record_version'   => $record->getVersion()
             ]
         );
+        $this->setFetchClass(false);
+        return $result;
     }
 
     /**
@@ -347,10 +364,12 @@ class PhpOrient implements ConfigurableInterface {
      * @return RecordCreate|Record
      */
     public function recordCreate(  Record $record ) {
-        return $this->getTransport()->execute( 'recordCreate', [
+        $result = $this->getTransport()->execute( 'recordCreate', [
             'cluster_id' => $record->getRid()->cluster,
             'record'     => $record
         ] );
+        $this->setFetchClass(false);
+        return $result;
     }
 
     /**
@@ -361,9 +380,11 @@ class PhpOrient implements ConfigurableInterface {
      * @return RecordDelete|bool
      */
     public function recordDelete( ID $rid ) {
-        return $this->getTransport()->execute( 'recordDelete', [
+        $result = $this->getTransport()->execute( 'recordDelete', [
             'rid'    => $rid
         ] );
+        $this->setFetchClass(false);
+        return $result;
     }
 
     /**
@@ -376,7 +397,9 @@ class PhpOrient implements ConfigurableInterface {
      */
     public function recordLoad( ID $rid, Array $params = array()  ) {
         $params[ 'rid' ]      = $rid;
-        return $this->getTransport()->execute( 'recordLoad', $params );
+        $result = $this->getTransport()->execute( 'recordLoad', $params );
+        $this->setFetchClass(false);
+        return $result;
     }
 
     /**
@@ -593,6 +616,36 @@ class PhpOrient implements ConfigurableInterface {
             'cluster_name' => $cluster_name,
             'cluster_type' => $cluster_type
         ] );
+    }
+
+    /**
+     * Allow the next query to be fetched in a custom class
+     *
+     * @param string $className
+     *
+     * @return $this
+     */
+    public function setFetchClass($className) {
+
+        if(class_exists($className) && is_subclass_of(new $className, 'PhpOrient\Protocols\Binary\Data\Record')) {
+            self::$fetchClass = $className;
+        } else {
+            self::$fetchClass = false;
+        }
+
+        return $this;
+
+    }
+
+    /**
+     * Get the current value of the fetch custom class name
+     *
+     * @return string|bool
+     */
+    public static function getFetchClass() {
+
+        return self::$fetchClass;
+
     }
 
 

--- a/src/PhpOrient/Protocols/Binary/Data/Record.php
+++ b/src/PhpOrient/Protocols/Binary/Data/Record.php
@@ -11,6 +11,7 @@ namespace PhpOrient\Protocols\Binary\Data;
 
 use PhpOrient\Protocols\Binary\Abstracts\SerializableInterface;
 use PhpOrient\Protocols\Common\ConfigurableTrait;
+use PhpOrient\PhpOrient;
 
 class Record implements \ArrayAccess, \JsonSerializable, SerializableInterface {
     use ConfigurableTrait;
@@ -41,7 +42,6 @@ class Record implements \ArrayAccess, \JsonSerializable, SerializableInterface {
      * @return ID
      */
     public function getRid() {
-        if( !$this->rid instanceof ID ) $this->rid = new ID();
         return $this->rid;
     }
 
@@ -257,6 +257,28 @@ class Record implements \ArrayAccess, \JsonSerializable, SerializableInterface {
      */
     public function __set( $name, $value ) {
         $this->offsetSet( $name, $value );
+    }
+
+    /**
+     * Override the ConfigurableTrait fromConfig method to handle custom classes for records
+     *
+     * @param array $options
+     *
+     * @return mixed
+     */
+    public static function fromConfig( Array $options = array() ) {
+
+        // Get the custom fetch class name if available
+        $fetchClass = PhpOrient::getFetchClass();
+
+        if($fetchClass) {
+            $object = new $fetchClass();
+        } else {
+            $object = new self();
+        }
+
+        return $object->configure( $options );
+
     }
 
 }

--- a/tests/PhpOrient/FetchClassTest.php
+++ b/tests/PhpOrient/FetchClassTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * User: Pierre-Julien MAZENOT ( pjmazenot )
+ * Date: 22/08/15
+ * Time: 15.56
+ */
+
+namespace PhpOrient;
+
+// Load test model
+require_once 'Model/TestClass.php';
+require_once 'Model/TestClassRecord.php';
+
+use PhpOrient\Abstracts\TestCase;
+use PhpOrient\Protocols\Binary\Data\ID;
+
+/**
+ * Class FetchClassTest
+ * @package PhpOrient
+ */
+class FetchClassTest extends TestCase {
+
+    protected $db_name = 'test_record_commands';
+
+    public function testSetFetchClass() {
+
+        $this->client->setFetchClass('PhpOrient\TestClassRecord');
+
+        $this->assertEquals('PhpOrient\TestClassRecord', PhpOrient::getFetchClass());
+
+        $this->client->setFetchClass('PhpOrient\TestClass');
+
+        $this->assertFalse(PhpOrient::getFetchClass());
+
+    }
+
+    public function testFetchClassQuery(){
+
+        $this->cluster_struct = $this->client->execute( 'dbOpen', [
+            'database' => 'GratefulDeadConcerts'
+        ] );
+
+        $this->client->setFetchClass('PhpOrient\TestClassRecord');
+        $res = $this->client->execute( 'recordLoad', ['rid' => new ID( "#9:5" )] );
+
+
+        $this->assertEquals('PhpOrient\TestClassRecord', get_class($res[0]));
+
+    }
+
+} 

--- a/tests/PhpOrient/Model/TestClass.php
+++ b/tests/PhpOrient/Model/TestClass.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * User: Pierre-Julien MAZENOT ( pjmazenot )
+ * Date: 22/08/15
+ * Time: 16.10
+ */
+
+namespace PhpOrient;
+
+/**
+ * Class TestClass
+ * @package PhpOrient
+ */
+class TestClass {
+
+}

--- a/tests/PhpOrient/Model/TestClassRecord.php
+++ b/tests/PhpOrient/Model/TestClassRecord.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * User: Pierre-Julien MAZENOT ( pjmazenot )
+ * Date: 22/08/15
+ * Time: 16.12
+ */
+
+namespace PhpOrient;
+
+use PhpOrient\Protocols\Binary\Data\Record;
+
+/**
+ * Class TestClassRecord
+ * @package PhpOrient
+ */
+class TestClassRecord extends Record {
+    
+}

--- a/tests/PhpOrient/SQLCommandsTest.php
+++ b/tests/PhpOrient/SQLCommandsTest.php
@@ -129,7 +129,13 @@ class SQLCommandsTest extends TestCase {
         $dateToTest = \DateTime::createFromFormat( 'U', time() )->format( 'Y-m-d H:i:s' );
 
         $result = $client->query("SELECT DATE( SYSDATE('yyy-MM-dd HH:mm:ss') ) FROM V LIMIT 1");
-        $this->assertEquals( $dateToTest, $result[0]->getOData()['DATE']->format('Y-m-d H:i:s') );
+        if(is_a($result[0]->getOData()['DATE'], '/DateTime')) {
+            $date = $result[0]->getOData()['DATE']->format('Y-m-d H:i:s');
+        } else {
+            $date = '"Not a DateTime instance"';
+        }
+
+        $this->assertEquals( $dateToTest,  $date);
 
     }
 


### PR DESCRIPTION
Usage: 

        $this->client->setFetchClass('PhpOrient\TestClassRecord');
        $res = $this->client->execute( 'recordLoad', ['rid' => new ID( "#9:5" )] );

Or

        $res = $this->client->setFetchClass('PhpOrient\TestClassRecord')->execute( 'recordLoad', ['rid' => new ID( "#9:5" )] );

Possible improvements: 
- Support of nested objects in result set
- Automatic class detection

I also added a quickfix for the fatal PHP error in the serialization test (commit 47e969d).