### PR TITLE
avoid Notice: Uninitialized string offset: 0

### DIFF
--- a/src/PhpOrient/Protocols/Binary/Serialization/CSV.php
+++ b/src/PhpOrient/Protocols/Binary/Serialization/CSV.php
@@ -226,7 +226,7 @@ class CSV {
 
         $input = substr( $input, $i );
 
-        $c = $input[ 0 ];
+        $c = @$input[ 0 ]; # avoid Notice: Uninitialized string offset: 0
 
         $useStrings = ( PHP_INT_SIZE == 4 );
 


### PR DESCRIPTION
If you have a record with one or more integer fields and use recordLoad function you will receive this "Uninitialized string offset" error. 

Take a look at 143 line on same file.
