### PR TITLE
Add more PHP/HHVM version to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ language: php
 php:
   - 5.4
   - 5.5
-  - 7.0.8
+  - 5.6
+  - 7.0
+  - nightly
   - hhvm
+  - hhvm-nightly
 
 install:
   - bash ./ci/_composer_install.sh


### PR DESCRIPTION
The package is now tested against PHP from 5.4 to 7.0. We also test against PHP and HHVM nightlies.
