### PR TITLE
Return null instead of throwing exception when accessing non existing property

### DIFF
--- a/src/PhpOrient/Protocols/Binary/Data/Record.php
+++ b/src/PhpOrient/Protocols/Binary/Data/Record.php
@@ -193,7 +193,7 @@ class Record implements \ArrayAccess, \JsonSerializable, SerializableInterface {
         if( @array_key_exists( $offset, $this->oData ) ){
             return $this->oData[ $offset ];
         } else {
-			return null;
+            return null;
         }
     }
 

--- a/src/PhpOrient/Protocols/Binary/Data/Record.php
+++ b/src/PhpOrient/Protocols/Binary/Data/Record.php
@@ -193,7 +193,7 @@ class Record implements \ArrayAccess, \JsonSerializable, SerializableInterface {
         if( @array_key_exists( $offset, $this->oData ) ){
             return $this->oData[ $offset ];
         } else {
-            throw new \OutOfBoundsException( 'The searched key ' . $offset . ' does not exists in this record: ' . var_export( $this, true ) );
+			return null;
         }
     }
 

--- a/src/PhpOrient/Protocols/Binary/Serialization/CSV.php
+++ b/src/PhpOrient/Protocols/Binary/Serialization/CSV.php
@@ -225,14 +225,18 @@ class CSV {
         }
 
         $input = substr( $input, $i );
-
+if(!isset($input[0])) {
+	return;
+}
         $c = $input[ 0 ];
 
         $useStrings = ( PHP_INT_SIZE == 4 );
 
         if ( $c === 'a' || $c === 't' ) {
             # date / 1000
-            $collected = \DateTime::createFromFormat( 'U', substr( $collected, 0, -3 ) );
+			$dt = new \DateTimeZone(date_default_timezone_get());
+            $collected = \DateTime::createFromFormat( 'U', substr( $collected, 0, -3 ));
+			$collected->setTimeZone($dt);
             $input     = substr( $input, 1 );
         } elseif ( $c === 'f' ) {
             // float


### PR DESCRIPTION
Since orientdb doesn't enforce any rigid schema and new properties can be added anytime, older records may not contain them.

Therefore it doesn't make any sense to throw an exception when accessing non existing properties.