### PR TITLE
Return null instead of throwing exception when accessing non existing…

### DIFF
--- a/src/PhpOrient/Protocols/Binary/Data/Record.php
+++ b/src/PhpOrient/Protocols/Binary/Data/Record.php
@@ -193,7 +193,7 @@ class Record implements \ArrayAccess, \JsonSerializable, SerializableInterface {
         if( @array_key_exists( $offset, $this->oData ) ){
             return $this->oData[ $offset ];
         } else {
-            throw new \OutOfBoundsException( 'The searched key ' . $offset . ' does not exists in this record: ' . var_export( $this, true ) );
+            return null;
         }
     }
 

--- a/src/PhpOrient/Protocols/Binary/Serialization/CSV.php
+++ b/src/PhpOrient/Protocols/Binary/Serialization/CSV.php
@@ -225,7 +225,10 @@ class CSV {
         }
 
         $input = substr( $input, $i );
-
+        if(!isset($input[0])) {
+	        return;
+        }
+		
         $c = $input[ 0 ];
 
         $useStrings = ( PHP_INT_SIZE == 4 );


### PR DESCRIPTION
Since orientdb doesn't enforce any rigid schema and new properties can be added anytime, older records may not contain them.

Therefore it doesn't make any sense to throw an exception when accessing non existing properties.